### PR TITLE
🛠 allow timeout of reminder sending functions to be configurable

### DIFF
--- a/functions/src/config.ts
+++ b/functions/src/config.ts
@@ -118,7 +118,7 @@ export interface RemindersConfig {
   app_link: string;
   /**
    * The maximum number of seconds that a function sending the reminders is
-   * allowed to run. Defaults to the maximum of 540. See
+   * allowed to run. Defaults to the GCP default, which is 60. See
    * https://firebase.google.com/docs/functions/manage-functions#set_timeout_and_memory_allocation.
    */
   timeout?: number;

--- a/functions/src/send-reminders.ts
+++ b/functions/src/send-reminders.ts
@@ -24,7 +24,7 @@ const campaignConfig = {
   startOn: asNumber(config.features.voting_campaigns.start_on),
   endOn: asNumber(config.features.voting_campaigns.end_on)
 };
-const timeout = config.features.reminders.timeout || 540;
+const timeout = config.features.reminders.timeout || 60;
 
 export const sendCampaignStartsReminder = functions
   .runWith({


### PR DESCRIPTION
This will allow us to configure a longer timeout so the function has time to send all the emails.