### PR TITLE
💚 fix ci authentication to firebase

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,7 +46,7 @@ commands:
             echo Using Firebase project: ${FIREBASE_PROJECT}
             SERVICE_ACCOUNT_KEY_VAR=SERVICE_ACCOUNT_KEY_${FIREBASE_PROJECT^^}
             echo Reading service account key from environment variable: ${SERVICE_ACCOUNT_KEY_VAR}
-            if [[ -z "${!SERVICE_ACCOUNT_KEY_VAR}" ]] then
+            if [ -z "${!SERVICE_ACCOUNT_KEY_VAR}" ] then
               echo Environment variable ${SERVICE_ACCOUNT_KEY_VAR} is empty!
               exit 1
             fi

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,6 +18,8 @@ executors:
   default:
     docker:
       - image: cimg/node:16.15.1
+    environment:
+      GOOGLE_APPLICATION_CREDENTIALS: google_application_credentials.json
 
 commands:
   install-dependency-as-global-package:
@@ -33,8 +35,8 @@ commands:
   setup-firebase-auth:
     steps:
       - run:
+          name: Set up Firebase authentication
           command: |
-            export GOOGLE_APPLICATION_CREDENTIALS=google_application_credentials.json
             echo ${GOOGLE_APPLICATION_CREDENTIALS_CONTENT_JSON} > ${GOOGLE_APPLICATION_CREDENTIALS}
             echo Service account key written to ${GOOGLE_APPLICATION_CREDENTIALS}
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -102,9 +102,6 @@ jobs:
       ui-build-config:
         type: string
         default: ""
-      google-application-credentials-content-json:
-        type: env_var_name
-        default: GOOGLE_APPLICATION_CREDENTIALS_CONTENT_JSON
     executor: default
     environment:
       HUMEUR_DU_MOIS_UI_FIREBASE_CONFIG: << parameters.ui-build-config >>

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -175,7 +175,8 @@ workflows:
           firebase-project: prod
           filters: &filters-only-prod-tag
             branches:
-              ignore: /.*/
+              # ignore: /.*/
+              only: new_firebase_auth_from_ci
             tags:
               only: /^v.+-prod.*/
       - check-config:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -175,8 +175,7 @@ workflows:
           firebase-project: prod
           filters: &filters-only-prod-tag
             branches:
-              # ignore: /.*/
-              only: new_firebase_auth_from_ci
+              ignore: /.*/
             tags:
               only: /^v.+-prod.*/
       - check-config:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,7 +47,8 @@ jobs:
       - checkout
       - install-dependency-as-global-package:
           package-name: firebase-tools
-      - run: firebase --project=<< parameters.firebase-project >> --token=$FIREBASE_APP_TOKEN functions:config:get > config.json
+      - setup-firebase-auth
+      - run: firebase --project=<< parameters.firebase-project >> functions:config:get > config.json
       - run: npx typescript-json-schema@0.50.0 --required --noExtraProps --out config-schema.json functions/src/config.ts Config
       - run: npx --package ajv-cli ajv validate -s config-schema.json -d config.json
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -151,7 +151,7 @@ workflows:
           filters: &filters-only-main
             branches:
               only:
-                - main
+                - new_firebase_auth_from_ci
 
       - validate-functions-config:
           name: prod-validate-functions-config

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,15 +43,15 @@ commands:
           environment:
             FIREBASE_PROJECT: << parameters.firebase-project >>
           command: |
-            echo Using Firebase project '${FIREBASE_PROJECT}'
+            echo Using Firebase project: ${FIREBASE_PROJECT}
             SERVICE_ACCOUNT_KEY_VAR=SERVICE_ACCOUNT_KEY_${FIREBASE_PROJECT^^}
-            Reading service account key from environment variable '${SERVICE_ACCOUNT_KEY_VAR}'
+            Reading service account key from environment variable: ${SERVICE_ACCOUNT_KEY_VAR}
             if [[ -z "${!SERVICE_ACCOUNT_KEY_VAR}" ]] then
-              echo Environment variable '${SERVICE_ACCOUNT_KEY_VAR}' is empty!
+              echo Environment variable ${SERVICE_ACCOUNT_KEY_VAR} is empty!
               exit 1
             fi
             echo ${!SERVICE_ACCOUNT_KEY_VAR} > ${GOOGLE_APPLICATION_CREDENTIALS}
-            echo Service account key written to '${GOOGLE_APPLICATION_CREDENTIALS}'
+            echo Service account key written to ${GOOGLE_APPLICATION_CREDENTIALS}
 
 jobs:
   validate-functions-config:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,7 +46,8 @@ commands:
             echo Using Firebase project: ${FIREBASE_PROJECT}
             SERVICE_ACCOUNT_KEY_VAR=SERVICE_ACCOUNT_KEY_${FIREBASE_PROJECT^^}
             echo Reading service account key from environment variable: ${SERVICE_ACCOUNT_KEY_VAR}
-            if [ -z "${!SERVICE_ACCOUNT_KEY_VAR}" ] then
+            if [ -z "${!SERVICE_ACCOUNT_KEY_VAR}" ]
+            then
               echo Environment variable ${SERVICE_ACCOUNT_KEY_VAR} is empty!
               exit 1
             fi

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,10 +49,9 @@ jobs:
     executor: default
     steps:
       - checkout
+      - setup-firebase-auth
       - install-dependency-as-global-package:
           package-name: firebase-tools
-      - setup-firebase-auth
-      - run: firebase --project=<< parameters.firebase-project >> functions:config:get
       - run: firebase --project=<< parameters.firebase-project >> functions:config:get > config.json
       - run: npx typescript-json-schema@0.50.0 --required --noExtraProps --out config-schema.json functions/src/config.ts Config
       - run: npx --package ajv-cli ajv validate -s config-schema.json -d config.json
@@ -65,9 +64,9 @@ jobs:
     executor: default
     steps:
       - checkout
+      - setup-firebase-auth
       - install-dependency-as-global-package:
           package-name: firebase-tools
-      - setup-firebase-auth
       - run: firebase --project=<< parameters.firebase-project >> functions:config:get > ./deployment/check-config/config.json
       - run: npm run config:check ./config.json
 
@@ -92,6 +91,7 @@ jobs:
       HUMEUR_DU_MOIS_UI_FIREBASE_CONFIG: << parameters.ui-build-config >>
     steps:
       - checkout
+      - setup-firebase-auth
       - node/install-packages:
           cache-version: << pipeline.parameters.tooling-dependencies-cache-version >>
       - node/install-packages:
@@ -100,7 +100,6 @@ jobs:
       - node/install-packages:
           app-dir: ui
           cache-version: << pipeline.parameters.ui-dependencies-cache-version >>
-      - setup-firebase-auth
       - run: npx firebase deploy --project=<< parameters.firebase-project >> --non-interactive --force
 
 workflows:
@@ -142,10 +141,8 @@ workflows:
       - check-formatting:
           filters: *filters-always
 
-      - validate-functions-config:
-          context: firebase-deploy-zenika
+      - validate-functions-config
       - deploy-firebase-app:
-          context: firebase-deploy-zenika
           requires:
             - build-ui
             - build-ui-for-production
@@ -159,7 +156,6 @@ workflows:
       - validate-functions-config:
           name: prod-validate-functions-config
           firebase-project: prod
-          context: firebase-deploy-zenika
           filters: &filters-only-prod-tag
             branches:
               ignore: /.*/
@@ -168,7 +164,6 @@ workflows:
       - check-config:
           name: prod-check-config
           firebase-project: prod
-          context: firebase-deploy-zenika
           requires:
             - test-tooling
           filters: *filters-only-prod-tag
@@ -185,7 +180,6 @@ workflows:
               "messagingSenderId": "777759273294",
               "appId": "1:777759273294:web:4bea510be52fdd6317ee1f"
             }
-          context: firebase-deploy-zenika
           requires:
             - build-ui
             - build-ui-for-production

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -168,7 +168,7 @@ workflows:
           filters: &filters-only-main
             branches:
               only:
-                - new_firebase_auth_from_ci
+                - main
 
       - validate-functions-config:
           name: prod-validate-functions-config

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,6 +30,11 @@ commands:
           command: |
             npm install --global \
               << parameters.package-name >>@$(node --print --eval='require("./package-lock.json").packages["node_modules/<< parameters.package-name >>"].version') \
+  setup-firebase-auth:
+    steps:
+      - run: export GOOGLE_APPLICATION_CREDENTIALS=google_application_credentials.json
+      - run: echo ${GOOGLE_APPLICATION_CREDENTIALS_CONTENT_JSON} > ${GOOGLE_APPLICATION_CREDENTIALS}
+      - run: echo Service account key written to ${GOOGLE_APPLICATION_CREDENTIALS}
 
 jobs:
   validate-functions-config:
@@ -56,7 +61,8 @@ jobs:
       - checkout
       - install-dependency-as-global-package:
           package-name: firebase-tools
-      - run: firebase --project=<< parameters.firebase-project >> --token=$FIREBASE_APP_TOKEN functions:config:get > ./deployment/check-config/config.json
+      - setup-firebase-auth
+      - run: firebase --project=<< parameters.firebase-project >> functions:config:get > ./deployment/check-config/config.json
       - run: npm run config:check ./config.json
 
   check-formatting:
@@ -88,7 +94,8 @@ jobs:
       - node/install-packages:
           app-dir: ui
           cache-version: << pipeline.parameters.ui-dependencies-cache-version >>
-      - run: npx firebase deploy --project=<< parameters.firebase-project >> --token=$FIREBASE_APP_TOKEN --non-interactive --force
+      - setup-firebase-auth
+      - run: npx firebase deploy --project=<< parameters.firebase-project >> --non-interactive --force
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,7 +45,7 @@ commands:
           command: |
             echo Using Firebase project: ${FIREBASE_PROJECT}
             SERVICE_ACCOUNT_KEY_VAR=SERVICE_ACCOUNT_KEY_${FIREBASE_PROJECT^^}
-            Reading service account key from environment variable: ${SERVICE_ACCOUNT_KEY_VAR}
+            echo Reading service account key from environment variable: ${SERVICE_ACCOUNT_KEY_VAR}
             if [[ -z "${!SERVICE_ACCOUNT_KEY_VAR}" ]] then
               echo Environment variable ${SERVICE_ACCOUNT_KEY_VAR} is empty!
               exit 1

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,6 +52,7 @@ jobs:
       - install-dependency-as-global-package:
           package-name: firebase-tools
       - setup-firebase-auth
+      - run: firebase --project=<< parameters.firebase-project >> functions:config:get
       - run: firebase --project=<< parameters.firebase-project >> functions:config:get > config.json
       - run: npx typescript-json-schema@0.50.0 --required --noExtraProps --out config-schema.json functions/src/config.ts Config
       - run: npx --package ajv-cli ajv validate -s config-schema.json -d config.json

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,12 +33,25 @@ commands:
             npm install --global \
               << parameters.package-name >>@$(node --print --eval='require("./package-lock.json").packages["node_modules/<< parameters.package-name >>"].version') \
   setup-firebase-auth:
+    parameters:
+      firebase-project:
+        type: string
+        default: default
     steps:
       - run:
           name: Set up Firebase authentication
+          environment:
+            FIREBASE_PROJECT: << parameters.firebase-project >>
           command: |
-            echo ${GOOGLE_APPLICATION_CREDENTIALS_CONTENT_JSON} > ${GOOGLE_APPLICATION_CREDENTIALS}
-            echo Service account key written to ${GOOGLE_APPLICATION_CREDENTIALS}
+            echo Using Firebase project '${FIREBASE_PROJECT}'
+            SERVICE_ACCOUNT_KEY_VAR=SERVICE_ACCOUNT_KEY_${FIREBASE_PROJECT^^}
+            Reading service account key from environment variable '${SERVICE_ACCOUNT_KEY_VAR}'
+            if [[ -z "${!SERVICE_ACCOUNT_KEY_VAR}" ]] then
+              echo Environment variable '${SERVICE_ACCOUNT_KEY_VAR}' is empty!
+              exit 1
+            fi
+            echo ${!SERVICE_ACCOUNT_KEY_VAR} > ${GOOGLE_APPLICATION_CREDENTIALS}
+            echo Service account key written to '${GOOGLE_APPLICATION_CREDENTIALS}'
 
 jobs:
   validate-functions-config:
@@ -49,7 +62,8 @@ jobs:
     executor: default
     steps:
       - checkout
-      - setup-firebase-auth
+      - setup-firebase-auth:
+          firebase-project: << parameters.firebase-project >>
       - install-dependency-as-global-package:
           package-name: firebase-tools
       - run: firebase --project=<< parameters.firebase-project >> functions:config:get > config.json
@@ -64,7 +78,8 @@ jobs:
     executor: default
     steps:
       - checkout
-      - setup-firebase-auth
+      - setup-firebase-auth:
+          firebase-project: << parameters.firebase-project >>
       - install-dependency-as-global-package:
           package-name: firebase-tools
       - run: firebase --project=<< parameters.firebase-project >> functions:config:get > ./deployment/check-config/config.json
@@ -86,12 +101,16 @@ jobs:
       ui-build-config:
         type: string
         default: ""
+      google-application-credentials-content-json:
+        type: env_var_name
+        default: GOOGLE_APPLICATION_CREDENTIALS_CONTENT_JSON
     executor: default
     environment:
       HUMEUR_DU_MOIS_UI_FIREBASE_CONFIG: << parameters.ui-build-config >>
     steps:
       - checkout
-      - setup-firebase-auth
+      - setup-firebase-auth:
+          firebase-project: << parameters.firebase-project >>
       - node/install-packages:
           cache-version: << pipeline.parameters.tooling-dependencies-cache-version >>
       - node/install-packages:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,9 +32,11 @@ commands:
               << parameters.package-name >>@$(node --print --eval='require("./package-lock.json").packages["node_modules/<< parameters.package-name >>"].version') \
   setup-firebase-auth:
     steps:
-      - run: export GOOGLE_APPLICATION_CREDENTIALS=google_application_credentials.json
-      - run: echo ${GOOGLE_APPLICATION_CREDENTIALS_CONTENT_JSON} > ${GOOGLE_APPLICATION_CREDENTIALS}
-      - run: echo Service account key written to ${GOOGLE_APPLICATION_CREDENTIALS}
+      - run:
+          command: |
+            export GOOGLE_APPLICATION_CREDENTIALS=google_application_credentials.json
+            echo ${GOOGLE_APPLICATION_CREDENTIALS_CONTENT_JSON} > ${GOOGLE_APPLICATION_CREDENTIALS}
+            echo Service account key written to ${GOOGLE_APPLICATION_CREDENTIALS}
 
 jobs:
   validate-functions-config:


### PR DESCRIPTION
Token authentication is deprecated, switching to service account authentication. See https://github.com/firebase/firebase-tools/blob/5811aea8ca0c9628cfdc3ef24ba57a9eb363e8b5/README.md#general.

I've created service accounts in both projects (default and prod), created one key for each, then created CircleCI project environment variables `SERVICE_ACCOUNT_KEY_DEFAULT` and `SERVICE_ACCOUNT_KEY_PROD` and set the respective keys in each.